### PR TITLE
[SDAO-127] Switch to two-step ownership transfer

### DIFF
--- a/contracts/BlendToken.sol
+++ b/contracts/BlendToken.sol
@@ -1,10 +1,10 @@
 pragma solidity ^0.5.0;
 
 import "@openzeppelin/upgrades/contracts/Initializable.sol";
-import "@openzeppelin/contracts-ethereum-package/contracts/ownership/Ownable.sol";
 import "@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/ERC20Detailed.sol";
 
+import {Ownable} from "./Ownable.sol";
 import {Registry} from "./Registry.sol";
 
 contract BlendToken is Initializable, Ownable, ERC20, ERC20Detailed {
@@ -31,6 +31,7 @@ contract BlendToken is Initializable, Ownable, ERC20, ERC20Detailed {
         initializer
     {
         ERC20Detailed.initialize("Blend Token", "BLEND", 18);
+        Ownable.initialize(_msgSender());
         _mint(initialHolder, initialSupply);
         registry = Registry(registryAddress);
         orchestrator = orchestratorAddress;

--- a/contracts/Orchestrator.sol
+++ b/contracts/Orchestrator.sol
@@ -8,11 +8,11 @@ pragma solidity ^0.5.0;
 pragma experimental ABIEncoderV2;
 
 import "@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts-ethereum-package/contracts/ownership/Ownable.sol";
 import "@openzeppelin/contracts-ethereum-package/contracts/math/SafeMath.sol";
 
-import {Registry} from "./Registry.sol";
 import {BlendToken} from "./BlendToken.sol";
+import {Ownable} from "./Ownable.sol";
+import {Registry} from "./Registry.sol";
 
 contract Orchestrator is Ownable {
     IERC20 public usdc;

--- a/contracts/Ownable.sol
+++ b/contracts/Ownable.sol
@@ -1,0 +1,86 @@
+pragma solidity ^0.5.0;
+
+import "@openzeppelin/upgrades/contracts/Initializable.sol";
+import "@openzeppelin/contracts-ethereum-package/contracts/GSN/Context.sol";
+
+/**
+ * @dev This contract is analogous to the one in @openzeppelin/contracts
+ * (most of the code is taken from there). However, it provides a two-step
+ * ownership transfer to guarantee that the new owner exists and posesses
+ * the private key from his account.
+ */
+contract Ownable is Initializable, Context {
+    address private _owner;
+    address private _pendingOwner;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev Initializes the contract setting the deployer as the initial owner.
+     */
+    function initialize(address sender) public initializer {
+        _owner = sender;
+        emit OwnershipTransferred(address(0), _owner);
+    }
+
+    /**
+     * @dev Returns the address of the current owner.
+     */
+    function owner() public view returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Returns the address of the pending owner.
+     */
+    function pendingOwner() public view returns (address) {
+        return _pendingOwner;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(isOwner(), "Ownable: caller is not the owner");
+        _;
+    }
+
+    /**
+     * @dev Returns true if the caller is the current owner.
+     */
+    function isOwner() public view returns (bool) {
+        return _msgSender() == _owner;
+    }
+
+    /**
+     * @dev Returns true if the caller is the pending owner.
+     */
+    function isPendingOwner() public view returns (bool) {
+        return _msgSender() == _pendingOwner;
+    }
+
+    /**
+     * @dev Updates the `_pendingOwner`. After `_pendingOwner` accepts the
+     * transfer using `acceptOwnership`, the `_owner` gets updated. Until
+     * then, the current owner holds the ownership.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        _pendingOwner = newOwner;
+    }
+
+    /**
+     * @dev Makes _pendingOwner accept the ownership, i.e. become
+     * the new `_owner`. The old `_owner` loses his rights.
+     */
+    function acceptOwnership() public {
+        require(
+            _pendingOwner == _msgSender(),
+            "Ownable: caller is not the pending owner"
+        );
+        emit OwnershipTransferred(_owner, _pendingOwner);
+        _owner = _pendingOwner;
+        _pendingOwner = address(0);
+    }
+
+    uint256[50] private ______gap;
+}

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -1,10 +1,11 @@
 pragma solidity ^0.5.0;
 
 import "@openzeppelin/upgrades/contracts/Initializable.sol";
-import "@openzeppelin/contracts-ethereum-package/contracts/ownership/Ownable.sol";
 import "@openzeppelin/contracts-ethereum-package/contracts/math/SafeMath.sol";
 
-contract Registry is Ownable {
+import {Ownable} from "./Ownable.sol";
+
+contract Registry is Initializable, Ownable {
     address public registryBackend;
     address public blend;
     uint256 public feePerAddress;

--- a/test/BlendToken.js
+++ b/test/BlendToken.js
@@ -14,11 +14,11 @@ describe('BlendToken', async function() {
         ctx.registry = await Registry.new({ from: owner })
         ctx.blend = await BlendToken.new({ from: owner })
 
-        const initializeBlend =
-            ctx.blend.methods['initialize(address,uint256,address,address)']
+        const BLEND_INIT = 'initialize(address,uint256,address,address)'
+        const initializeBlend = ctx.blend.methods[BLEND_INIT]
 
-        const initializeRegistry =
-            ctx.registry.methods['initialize(address,address)']
+        const REGISTRY_INIT = 'initialize(address,address)'
+        const initializeRegistry = ctx.registry.methods[REGISTRY_INIT]
 
         await initializeBlend(
             alice,
@@ -39,6 +39,40 @@ describe('BlendToken', async function() {
         await initialize()
         await ctx.registry.registerTenderAddress.sendTransaction(
             tenderAddress, { from: registryBackend }
+        )
+    })
+
+    describe('Setting registry address', async function() {
+        it('Allows owner to change registry address', async function() {
+            await ctx.blend.setRegistry(bob, {from: owner})
+            const newRegistry = await ctx.blend.registry()
+            expect(newRegistry).to.equal(bob)
+        })
+
+        it('Prohibits someone else to change the registry address',
+            async function() {
+                await expectRevert(
+                    ctx.blend.setRegistry(bob, {from: registryBackend}),
+                    'Ownable: caller is not the owner'
+                )
+            }
+        )
+    })
+
+    describe('Setting orchestrator address', async function() {
+        it('Allows owner to change orchestrator address', async function() {
+            await ctx.blend.setOrchestrator(bob, {from: owner})
+            const newOrchestrator = await ctx.blend.orchestrator()
+            expect(newOrchestrator).to.equal(bob)
+        })
+
+        it('Prohibits someone else to change the orchestrator address',
+            async function() {
+                await expectRevert(
+                    ctx.blend.setOrchestrator(bob, {from: registryBackend}),
+                    'Ownable: caller is not the owner'
+                )
+            }
         )
     })
 

--- a/test/Ownable.js
+++ b/test/Ownable.js
@@ -1,0 +1,103 @@
+const { accounts, contract } = require('@openzeppelin/test-environment')
+const { expectRevert, constants } = require('@openzeppelin/test-helpers')
+const { expect } = require('chai')
+const Ownable = contract.fromArtifact('Ownable')
+
+describe('Ownable', async function() {
+    const [owner, newOwner, eva] = accounts
+    const ctx = {}
+
+    beforeEach(async function() {
+        ctx.ownable = await Ownable.new({from: owner})
+        await ctx.ownable.initialize(owner, {from: owner})
+    })
+
+    describe('Initialization', async function() {
+        it('Sets the owner upon initialization', async function() {
+            expect(await ctx.ownable.owner()).to.equal(owner)
+        })
+
+        it('Does not set the pending owner upon initialization',
+            async function() {
+                expect(
+                    await ctx.ownable.pendingOwner()
+                ).to.equal(constants.ZERO_ADDRESS)
+            }
+        )
+    })
+
+    describe('transferOwnership', async function() {
+        it('Sets the pending owner if called by current owner',
+            async function() {
+                await ctx.ownable.transferOwnership(newOwner, {from: owner})
+                expect(await ctx.ownable.pendingOwner()).to.equal(newOwner)
+                expect(
+                    await ctx.ownable.isPendingOwner({from: newOwner})
+                ).to.equal(true)
+            }
+        )
+
+        it('Does not change the current owner', async function() {
+            await ctx.ownable.transferOwnership(newOwner, {from: owner})
+            expect(await ctx.ownable.owner()).to.equal(owner)
+            expect(
+                await ctx.ownable.isOwner({from: owner})
+            ).to.equal(true)
+        })
+
+        it('Fails if called by Eva', async function() {
+            await expectRevert(
+                ctx.ownable.transferOwnership(newOwner, {from: eva}),
+                'Ownable: caller is not the owner'
+            )
+        })
+
+        it('Fails if called by pending owner', async function() {
+            await ctx.ownable.transferOwnership(newOwner, {from: owner})
+            await expectRevert(
+                ctx.ownable.transferOwnership(eva, {from: newOwner}),
+                'Ownable: caller is not the owner'
+            )
+        })
+    })
+
+    describe('acceptOwnership', async function() {
+        it('Fails if pending owner has not been set', async function() {
+            await expectRevert(
+                ctx.ownable.acceptOwnership({from: newOwner}),
+                'Ownable: caller is not the pending owner'
+            )
+        })
+
+        it('Fails if not called by pending owner', async function() {
+            await ctx.ownable.transferOwnership(newOwner, {from: owner})
+            await expectRevert(
+                ctx.ownable.acceptOwnership({from: eva}),
+                'Ownable: caller is not the pending owner'
+            )
+        })
+
+        it('Transfers ownership if called by pending owner', async function() {
+            await ctx.ownable.transferOwnership(newOwner, {from: owner})
+            await ctx.ownable.acceptOwnership({from: newOwner})
+
+            expect(
+                await ctx.ownable.pendingOwner()
+            ).to.equal(constants.ZERO_ADDRESS)
+
+            expect(
+                await ctx.ownable.isPendingOwner({from: newOwner})
+            ).to.equal(false)
+
+            expect(await ctx.ownable.owner()).to.equal(newOwner)
+
+            expect(
+                await ctx.ownable.isOwner({from: newOwner})
+            ).to.equal(true)
+
+            expect(
+                await ctx.ownable.isOwner({from: owner})
+            ).to.equal(false)
+        })
+    })
+})


### PR DESCRIPTION
[//]: # (This is a template of a pull request template.)
[//]: # (You should modify it considering specifics of a particular repository and put it there.)
[//]: # (Comments like this are meta-comments, they shouldn't be present in the final template.)
[//]: # (Comments starting with '<!---' are intended to stay in the final template.)

[//]: # (Keep in mind that it's only a template which contains items relevant to almost all conceivable repository.)
[//]: # (There can be other important items relevant to your repository that you can add here.)

## Description

Problem: Currently, it is possible to invoke `{blend,orchestrator,registry}.transferOwnership(newOwner)` from the current owner's address to set the new owner. However, mistakes happen, and it is possible that the new address would have no private key associated with it. This can potentially block the backend key rotation for all the contracts, and it would be impossible to call `orchestrator.collectBlend`

Solution: Use two-step ownership trasfer, i.e. add a contract that, unlike the standard Ownable, implements an additional `acceptOwnership` method that actually transfers the ownership. `transferOwnership` endpoint, in turn, would not actually do the transfer but rather set a `pendingOwner` of the contract. Until `acceptTransfer` is called, the current `owner` possesses the ownership rights.

[//]: # (Here you can add a link to the corresponding issue tracker, e. g. https://issues.serokell.io/issue/SDAO-98)
## Related issue(s)

https://issues.serokell.io/issue/SDAO-127

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

[//]: # (Mostly for public repositories)
[//]: # (Recording changes is optional, depends on repository, useful for some libs)
- Public contracts
  - [ ] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [ ] I added an entry to the [changelog](../tree/master/CHANGES.md) if my changes are visible to the users
        and
  - [ ] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

[//]: # (Update link to style guide if necesary or remove if it's not present)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
