### PR TITLE
[SDAO-212] Fix compilation & tests after incorrect mint/burn push

### DIFF
--- a/contracts/BlendToken.sol
+++ b/contracts/BlendToken.sol
@@ -153,7 +153,7 @@ contract BlendToken is Initializable, Ownable, ERC20, ERC20Detailed {
     /// @notice Burns sender's tokens.
     /// @param amount Amount to burn
     function burn(uint256 amount) public {
-        _burn(_msgSender, amount);
+        _burn(_msgSender(), amount);
     }
 
     /// @notice Mints tokens to the beneficiary.

--- a/package-lock.json
+++ b/package-lock.json
@@ -717,6 +717,237 @@
         "web3": "1.2.2"
       },
       "dependencies": {
+        "@truffle/blockchain-utils": {
+          "version": "0.0.25",
+          "resolved": "https://registry.npmjs.org/@truffle/blockchain-utils/-/blockchain-utils-0.0.25.tgz",
+          "integrity": "sha512-XA5m0BfAWtysy5ChHyiAf1fXbJxJXphKk+eZ9Rb9Twi6fn3Jg4gnHNwYXJacYFEydqT5vr2s4Ou812JHlautpw==",
+          "dev": true,
+          "requires": {
+            "source-map-support": "^0.5.19"
+          }
+        },
+        "@truffle/codec": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/@truffle/codec/-/codec-0.6.1.tgz",
+          "integrity": "sha512-HrInHX9yLVVRCGOsXG2mZNG5P724KHZH3Pez6tMn39yLPsiKm9CzHcAHF5uX7ExhponOTEtKViudQ4MAFfh9Jg==",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "bn.js": "^4.11.8",
+            "borc": "^2.1.2",
+            "debug": "^4.1.0",
+            "lodash.clonedeep": "^4.5.0",
+            "lodash.escaperegexp": "^4.1.2",
+            "lodash.partition": "^4.6.0",
+            "lodash.sum": "^4.0.2",
+            "semver": "^6.3.0",
+            "source-map-support": "^0.5.19",
+            "utf8": "^3.0.0",
+            "web3-utils": "1.2.1"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+              "dev": true
+            },
+            "web3-utils": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
+              "integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+              "dev": true,
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randomhex": "0.1.5",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              },
+              "dependencies": {
+                "bn.js": {
+                  "version": "4.11.8",
+                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+                  "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "@truffle/contract": {
+          "version": "4.2.22",
+          "resolved": "https://registry.npmjs.org/@truffle/contract/-/contract-4.2.22.tgz",
+          "integrity": "sha512-mkkuQucuZb+kHlnDwcEF5CXKa7c3hZRTN7y0NSVGlNKPMAd+VMoGi4RsJy3o0ALAumsxi714sGMHJagqoz/RmA==",
+          "dev": true,
+          "requires": {
+            "@truffle/blockchain-utils": "^0.0.25",
+            "@truffle/contract-schema": "^3.2.5",
+            "@truffle/debug-utils": "^4.2.8",
+            "@truffle/error": "^0.0.11",
+            "@truffle/interface-adapter": "^0.4.16",
+            "bignumber.js": "^7.2.1",
+            "ethereum-ens": "^0.8.0",
+            "ethers": "^4.0.0-beta.1",
+            "source-map-support": "^0.5.19",
+            "web3": "1.2.1",
+            "web3-core-helpers": "1.2.1",
+            "web3-core-promievent": "1.2.1",
+            "web3-eth-abi": "1.2.1",
+            "web3-utils": "1.2.1"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.8",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+              "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+              "dev": true
+            },
+            "web3": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/web3/-/web3-1.2.1.tgz",
+              "integrity": "sha512-nNMzeCK0agb5i/oTWNdQ1aGtwYfXzHottFP2Dz0oGIzavPMGSKyVlr8ibVb1yK5sJBjrWVnTdGaOC2zKDFuFRw==",
+              "dev": true,
+              "requires": {
+                "web3-bzz": "1.2.1",
+                "web3-core": "1.2.1",
+                "web3-eth": "1.2.1",
+                "web3-eth-personal": "1.2.1",
+                "web3-net": "1.2.1",
+                "web3-shh": "1.2.1",
+                "web3-utils": "1.2.1"
+              }
+            },
+            "web3-bzz": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.1.tgz",
+              "integrity": "sha512-LdOO44TuYbGIPfL4ilkuS89GQovxUpmLz6C1UC7VYVVRILeZS740FVB3j9V4P4FHUk1RenaDfKhcntqgVCHtjw==",
+              "dev": true,
+              "requires": {
+                "got": "9.6.0",
+                "swarm-js": "0.1.39",
+                "underscore": "1.9.1"
+              }
+            },
+            "web3-core": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.1.tgz",
+              "integrity": "sha512-5ODwIqgl8oIg/0+Ai4jsLxkKFWJYE0uLuE1yUKHNVCL4zL6n3rFjRMpKPokd6id6nJCNgeA64KdWQ4XfpnjdMg==",
+              "dev": true,
+              "requires": {
+                "web3-core-helpers": "1.2.1",
+                "web3-core-method": "1.2.1",
+                "web3-core-requestmanager": "1.2.1",
+                "web3-utils": "1.2.1"
+              }
+            },
+            "web3-eth": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.1.tgz",
+              "integrity": "sha512-/2xly4Yry5FW1i+uygPjhfvgUP/MS/Dk+PDqmzp5M88tS86A+j8BzKc23GrlA8sgGs0645cpZK/999LpEF5UdA==",
+              "dev": true,
+              "requires": {
+                "underscore": "1.9.1",
+                "web3-core": "1.2.1",
+                "web3-core-helpers": "1.2.1",
+                "web3-core-method": "1.2.1",
+                "web3-core-subscriptions": "1.2.1",
+                "web3-eth-abi": "1.2.1",
+                "web3-eth-accounts": "1.2.1",
+                "web3-eth-contract": "1.2.1",
+                "web3-eth-ens": "1.2.1",
+                "web3-eth-iban": "1.2.1",
+                "web3-eth-personal": "1.2.1",
+                "web3-net": "1.2.1",
+                "web3-utils": "1.2.1"
+              }
+            },
+            "web3-eth-personal": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.1.tgz",
+              "integrity": "sha512-RNDVSiaSoY4aIp8+Hc7z+X72H7lMb3fmAChuSBADoEc7DsJrY/d0R5qQDK9g9t2BO8oxgLrLNyBP/9ub2Hc6Bg==",
+              "dev": true,
+              "requires": {
+                "web3-core": "1.2.1",
+                "web3-core-helpers": "1.2.1",
+                "web3-core-method": "1.2.1",
+                "web3-net": "1.2.1",
+                "web3-utils": "1.2.1"
+              }
+            },
+            "web3-net": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.1.tgz",
+              "integrity": "sha512-Yt1Bs7WgnLESPe0rri/ZoPWzSy55ovioaP35w1KZydrNtQ5Yq4WcrAdhBzcOW7vAkIwrsLQsvA+hrOCy7mNauw==",
+              "dev": true,
+              "requires": {
+                "web3-core": "1.2.1",
+                "web3-core-method": "1.2.1",
+                "web3-utils": "1.2.1"
+              }
+            },
+            "web3-shh": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.1.tgz",
+              "integrity": "sha512-/3Cl04nza5kuFn25bV3FJWa0s3Vafr5BlT933h26xovQ6HIIz61LmvNQlvX1AhFL+SNJOTcQmK1SM59vcyC8bA==",
+              "dev": true,
+              "requires": {
+                "web3-core": "1.2.1",
+                "web3-core-method": "1.2.1",
+                "web3-core-subscriptions": "1.2.1",
+                "web3-net": "1.2.1"
+              }
+            },
+            "web3-utils": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
+              "integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+              "dev": true,
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randomhex": "0.1.5",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
+            }
+          }
+        },
+        "@truffle/contract-schema": {
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/@truffle/contract-schema/-/contract-schema-3.2.5.tgz",
+          "integrity": "sha512-07lzyYJinGvpaKc/WUm1sigtE5qDjFfUb/wUfV5cNsUmRSd/Ji9vTZ+of/zYP4MztJQLT/ZtuG836oXhWgqntg==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.10.0",
+            "crypto-js": "^3.1.9-1",
+            "debug": "^4.1.0"
+          }
+        },
+        "@truffle/debug-utils": {
+          "version": "4.2.8",
+          "resolved": "https://registry.npmjs.org/@truffle/debug-utils/-/debug-utils-4.2.8.tgz",
+          "integrity": "sha512-o1apbR4FpQDVNCtT7nnXDAmHKGHEOVGuXyz9QG/IhjRdqxwZEE0pzBAW13tdIwduNaj6TQQVTB/Fx8uz914qzg==",
+          "dev": true,
+          "requires": {
+            "@truffle/codec": "^0.6.1",
+            "@trufflesuite/chromafi": "^2.1.2",
+            "chalk": "^2.4.2",
+            "debug": "^4.1.0",
+            "highlight.js": "^9.15.8",
+            "highlightjs-solidity": "^1.0.18"
+          }
+        },
+        "@truffle/error": {
+          "version": "0.0.11",
+          "resolved": "https://registry.npmjs.org/@truffle/error/-/error-0.0.11.tgz",
+          "integrity": "sha512-ju6TucjlJkfYMmdraYY/IBJaFb+Sa+huhYtOoyOJ+G29KcgytUVnDzKGwC7Kgk6IsxQMm62Mc1E0GZzFbGGipw==",
+          "dev": true
+        },
         "@types/node": {
           "version": "12.12.53",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.53.tgz",
@@ -733,6 +964,32 @@
             "@types/underscore": "*"
           }
         },
+        "bignumber.js": {
+          "version": "7.2.1",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
+          "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
         "find-up": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -743,6 +1000,22 @@
             "path-exists": "^4.0.0"
           }
         },
+        "hash.js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "highlightjs-solidity": {
+          "version": "1.0.18",
+          "resolved": "https://registry.npmjs.org/highlightjs-solidity/-/highlightjs-solidity-1.0.18.tgz",
+          "integrity": "sha512-k15h0br4oCRT0F0jTRuZbimerVt5V4n0k25h7oWi0kVqlBNeXPbSr5ddw02/2ukJmYfB8jauFDmxSauJjwM7Eg==",
+          "dev": true
+        },
         "locate-path": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -751,6 +1024,12 @@
           "requires": {
             "p-locate": "^4.1.0"
           }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
         },
         "p-limit": {
           "version": "2.3.0",
@@ -782,10 +1061,34 @@
           "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
           "dev": true
         },
+        "scrypt-js": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
+          "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q=",
+          "dev": true
+        },
         "semver": {
           "version": "7.3.2",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
           "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true
+        },
+        "setimmediate": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
+          "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48=",
+          "dev": true
+        },
+        "underscore": {
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+          "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==",
+          "dev": true
+        },
+        "uuid": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
           "dev": true
         },
         "web3": {
@@ -802,6 +1105,415 @@
             "web3-net": "1.2.2",
             "web3-shh": "1.2.2",
             "web3-utils": "1.2.2"
+          }
+        },
+        "web3-core-helpers": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.1.tgz",
+          "integrity": "sha512-Gx3sTEajD5r96bJgfuW377PZVFmXIH4TdqDhgGwd2lZQCcMi+DA4TgxJNJGxn0R3aUVzyyE76j4LBrh412mXrw==",
+          "dev": true,
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-eth-iban": "1.2.1",
+            "web3-utils": "1.2.1"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.8",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+              "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+              "dev": true
+            },
+            "web3-utils": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
+              "integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+              "dev": true,
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randomhex": "0.1.5",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
+            }
+          }
+        },
+        "web3-core-method": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.1.tgz",
+          "integrity": "sha512-Ghg2WS23qi6Xj8Od3VCzaImLHseEA7/usvnOItluiIc5cKs00WYWsNy2YRStzU9a2+z8lwQywPYp0nTzR/QXdQ==",
+          "dev": true,
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.1",
+            "web3-core-promievent": "1.2.1",
+            "web3-core-subscriptions": "1.2.1",
+            "web3-utils": "1.2.1"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.8",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+              "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+              "dev": true
+            },
+            "web3-utils": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
+              "integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+              "dev": true,
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randomhex": "0.1.5",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
+            }
+          }
+        },
+        "web3-core-promievent": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.1.tgz",
+          "integrity": "sha512-IVUqgpIKoeOYblwpex4Hye6npM0aMR+kU49VP06secPeN0rHMyhGF0ZGveWBrGvf8WDPI7jhqPBFIC6Jf3Q3zw==",
+          "dev": true,
+          "requires": {
+            "any-promise": "1.3.0",
+            "eventemitter3": "3.1.2"
+          }
+        },
+        "web3-core-requestmanager": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.1.tgz",
+          "integrity": "sha512-xfknTC69RfYmLKC+83Jz73IC3/sS2ZLhGtX33D4Q5nQ8yc39ElyAolxr9sJQS8kihOcM6u4J+8gyGMqsLcpIBg==",
+          "dev": true,
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.1",
+            "web3-providers-http": "1.2.1",
+            "web3-providers-ipc": "1.2.1",
+            "web3-providers-ws": "1.2.1"
+          }
+        },
+        "web3-core-subscriptions": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.1.tgz",
+          "integrity": "sha512-nmOwe3NsB8V8UFsY1r+sW6KjdOS68h8nuh7NzlWxBQT/19QSUGiERRTaZXWu5BYvo1EoZRMxCKyCQpSSXLc08g==",
+          "dev": true,
+          "requires": {
+            "eventemitter3": "3.1.2",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.1"
+          }
+        },
+        "web3-eth-abi": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.1.tgz",
+          "integrity": "sha512-jI/KhU2a/DQPZXHjo2GW0myEljzfiKOn+h1qxK1+Y9OQfTcBMxrQJyH5AP89O6l6NZ1QvNdq99ThAxBFoy5L+g==",
+          "dev": true,
+          "requires": {
+            "ethers": "4.0.0-beta.3",
+            "underscore": "1.9.1",
+            "web3-utils": "1.2.1"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "10.17.35",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.35.tgz",
+              "integrity": "sha512-gXx7jAWpMddu0f7a+L+txMplp3FnHl53OhQIF9puXKq3hDGY/GjH+MF04oWnV/adPSCrbtHumDCFwzq2VhltWA==",
+              "dev": true
+            },
+            "elliptic": {
+              "version": "6.3.3",
+              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
+              "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
+              "dev": true,
+              "requires": {
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "inherits": "^2.0.1"
+              }
+            },
+            "ethers": {
+              "version": "4.0.0-beta.3",
+              "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.0-beta.3.tgz",
+              "integrity": "sha512-YYPogooSknTwvHg3+Mv71gM/3Wcrx+ZpCzarBj3mqs9njjRkrOo2/eufzhHloOCo3JSoNI4TQJJ6yU5ABm3Uog==",
+              "dev": true,
+              "requires": {
+                "@types/node": "^10.3.2",
+                "aes-js": "3.0.0",
+                "bn.js": "^4.4.0",
+                "elliptic": "6.3.3",
+                "hash.js": "1.1.3",
+                "js-sha3": "0.5.7",
+                "scrypt-js": "2.0.3",
+                "setimmediate": "1.0.4",
+                "uuid": "2.0.1",
+                "xmlhttprequest": "1.8.0"
+              }
+            },
+            "web3-utils": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
+              "integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+              "dev": true,
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randomhex": "0.1.5",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              },
+              "dependencies": {
+                "bn.js": {
+                  "version": "4.11.8",
+                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+                  "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "web3-eth-accounts": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.1.tgz",
+          "integrity": "sha512-26I4qq42STQ8IeKUyur3MdQ1NzrzCqPsmzqpux0j6X/XBD7EjZ+Cs0lhGNkSKH5dI3V8CJasnQ5T1mNKeWB7nQ==",
+          "dev": true,
+          "requires": {
+            "any-promise": "1.3.0",
+            "crypto-browserify": "3.12.0",
+            "eth-lib": "0.2.7",
+            "scryptsy": "2.1.0",
+            "semver": "6.2.0",
+            "underscore": "1.9.1",
+            "uuid": "3.3.2",
+            "web3-core": "1.2.1",
+            "web3-core-helpers": "1.2.1",
+            "web3-core-method": "1.2.1",
+            "web3-utils": "1.2.1"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.8",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+              "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+              "dev": true
+            },
+            "semver": {
+              "version": "6.2.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.2.0.tgz",
+              "integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A==",
+              "dev": true
+            },
+            "uuid": {
+              "version": "3.3.2",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+              "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+              "dev": true
+            },
+            "web3-core": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.1.tgz",
+              "integrity": "sha512-5ODwIqgl8oIg/0+Ai4jsLxkKFWJYE0uLuE1yUKHNVCL4zL6n3rFjRMpKPokd6id6nJCNgeA64KdWQ4XfpnjdMg==",
+              "dev": true,
+              "requires": {
+                "web3-core-helpers": "1.2.1",
+                "web3-core-method": "1.2.1",
+                "web3-core-requestmanager": "1.2.1",
+                "web3-utils": "1.2.1"
+              }
+            },
+            "web3-utils": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
+              "integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+              "dev": true,
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randomhex": "0.1.5",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
+            }
+          }
+        },
+        "web3-eth-contract": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.1.tgz",
+          "integrity": "sha512-kYFESbQ3boC9bl2rYVghj7O8UKMiuKaiMkxvRH5cEDHil8V7MGEGZNH0slSdoyeftZVlaWSMqkRP/chfnKND0g==",
+          "dev": true,
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core": "1.2.1",
+            "web3-core-helpers": "1.2.1",
+            "web3-core-method": "1.2.1",
+            "web3-core-promievent": "1.2.1",
+            "web3-core-subscriptions": "1.2.1",
+            "web3-eth-abi": "1.2.1",
+            "web3-utils": "1.2.1"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.8",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+              "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+              "dev": true
+            },
+            "web3-core": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.1.tgz",
+              "integrity": "sha512-5ODwIqgl8oIg/0+Ai4jsLxkKFWJYE0uLuE1yUKHNVCL4zL6n3rFjRMpKPokd6id6nJCNgeA64KdWQ4XfpnjdMg==",
+              "dev": true,
+              "requires": {
+                "web3-core-helpers": "1.2.1",
+                "web3-core-method": "1.2.1",
+                "web3-core-requestmanager": "1.2.1",
+                "web3-utils": "1.2.1"
+              }
+            },
+            "web3-utils": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
+              "integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+              "dev": true,
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randomhex": "0.1.5",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
+            }
+          }
+        },
+        "web3-eth-ens": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.1.tgz",
+          "integrity": "sha512-lhP1kFhqZr2nnbu3CGIFFrAnNxk2veXpOXBY48Tub37RtobDyHijHgrj+xTh+mFiPokyrapVjpFsbGa+Xzye4Q==",
+          "dev": true,
+          "requires": {
+            "eth-ens-namehash": "2.0.8",
+            "underscore": "1.9.1",
+            "web3-core": "1.2.1",
+            "web3-core-helpers": "1.2.1",
+            "web3-core-promievent": "1.2.1",
+            "web3-eth-abi": "1.2.1",
+            "web3-eth-contract": "1.2.1",
+            "web3-utils": "1.2.1"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.8",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+              "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+              "dev": true
+            },
+            "web3-core": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.1.tgz",
+              "integrity": "sha512-5ODwIqgl8oIg/0+Ai4jsLxkKFWJYE0uLuE1yUKHNVCL4zL6n3rFjRMpKPokd6id6nJCNgeA64KdWQ4XfpnjdMg==",
+              "dev": true,
+              "requires": {
+                "web3-core-helpers": "1.2.1",
+                "web3-core-method": "1.2.1",
+                "web3-core-requestmanager": "1.2.1",
+                "web3-utils": "1.2.1"
+              }
+            },
+            "web3-utils": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
+              "integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+              "dev": true,
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randomhex": "0.1.5",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
+            }
+          }
+        },
+        "web3-eth-iban": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.1.tgz",
+          "integrity": "sha512-9gkr4QPl1jCU+wkgmZ8EwODVO3ovVj6d6JKMos52ggdT2YCmlfvFVF6wlGLwi0VvNa/p+0BjJzaqxnnG/JewjQ==",
+          "dev": true,
+          "requires": {
+            "bn.js": "4.11.8",
+            "web3-utils": "1.2.1"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.8",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+              "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+              "dev": true
+            },
+            "web3-utils": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
+              "integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+              "dev": true,
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randomhex": "0.1.5",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
+            }
+          }
+        },
+        "web3-providers-http": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.1.tgz",
+          "integrity": "sha512-BDtVUVolT9b3CAzeGVA/np1hhn7RPUZ6YYGB/sYky+GjeO311Yoq8SRDUSezU92x8yImSC2B+SMReGhd1zL+bQ==",
+          "dev": true,
+          "requires": {
+            "web3-core-helpers": "1.2.1",
+            "xhr2-cookies": "1.1.0"
+          }
+        },
+        "web3-providers-ipc": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.1.tgz",
+          "integrity": "sha512-oPEuOCwxVx8L4CPD0TUdnlOUZwGBSRKScCz/Ws2YHdr9Ium+whm+0NLmOZjkjQp5wovQbyBzNa6zJz1noFRvFA==",
+          "dev": true,
+          "requires": {
+            "oboe": "2.1.4",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.1"
+          }
+        },
+        "web3-providers-ws": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.1.tgz",
+          "integrity": "sha512-oqsQXzu+ejJACVHy864WwIyw+oB21nw/pI65/sD95Zi98+/HQzFfNcIFneF1NC4bVF3VNX4YHTNq2I2o97LAiA==",
+          "dev": true,
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.1",
+            "websocket": "github:web3-js/WebSocket-Node#polyfill/globalThis"
           }
         }
       }
@@ -1675,20 +2387,23 @@
       }
     },
     "@truffle/blockchain-utils": {
-      "version": "0.0.22",
-      "resolved": "https://registry.npmjs.org/@truffle/blockchain-utils/-/blockchain-utils-0.0.22.tgz",
-      "integrity": "sha512-YyIQPMjFn/Ch8gARX+m8NJAlQecPkFRjHv0oHpZi1LlNGZ52vEt21z0ZelAu5ti6nQJ2Us6mE4BNyywfrqgiAA==",
+      "version": "0.0.25",
+      "resolved": "https://registry.npmjs.org/@truffle/blockchain-utils/-/blockchain-utils-0.0.25.tgz",
+      "integrity": "sha512-XA5m0BfAWtysy5ChHyiAf1fXbJxJXphKk+eZ9Rb9Twi6fn3Jg4gnHNwYXJacYFEydqT5vr2s4Ou812JHlautpw==",
+      "dev": true,
       "requires": {
         "source-map-support": "^0.5.19"
       }
     },
     "@truffle/codec": {
-      "version": "0.5.9",
-      "resolved": "https://registry.npmjs.org/@truffle/codec/-/codec-0.5.9.tgz",
-      "integrity": "sha512-W9YTUYttpiL9w770Mu+viOK7dgUE1ClX6iFo5YdJMwBQg2jkX+pjXLcYLJtD6657GHlhVQEnZCHztFIzG9FiHw==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@truffle/codec/-/codec-0.6.1.tgz",
+      "integrity": "sha512-HrInHX9yLVVRCGOsXG2mZNG5P724KHZH3Pez6tMn39yLPsiKm9CzHcAHF5uX7ExhponOTEtKViudQ4MAFfh9Jg==",
+      "dev": true,
       "requires": {
         "big.js": "^5.2.2",
         "bn.js": "^4.11.8",
+        "borc": "^2.1.2",
         "debug": "^4.1.0",
         "lodash.clonedeep": "^4.5.0",
         "lodash.escaperegexp": "^4.1.2",
@@ -1701,17 +2416,19 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+          "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "eth-lib": {
           "version": "0.2.7",
           "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
           "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "dev": true,
           "requires": {
             "bn.js": "^4.11.6",
             "elliptic": "^6.4.0",
@@ -1721,22 +2438,26 @@
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
         },
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
         },
         "underscore": {
           "version": "1.9.1",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
-          "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
+          "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==",
+          "dev": true
         },
         "web3-utils": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
           "integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+          "dev": true,
           "requires": {
             "bn.js": "4.11.8",
             "eth-lib": "0.2.7",
@@ -1750,22 +2471,24 @@
             "bn.js": {
               "version": "4.11.8",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-              "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+              "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+              "dev": true
             }
           }
         }
       }
     },
     "@truffle/contract": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@truffle/contract/-/contract-4.2.14.tgz",
-      "integrity": "sha512-LGkfFXIjTNUZuf59Kh1V8bYR7nIQXPTDqzv3ew3bkP15mQWbL0xp9fSjLE1ZrC8MXzmXYXPDGSzlHAv8Fjkaxg==",
+      "version": "4.2.22",
+      "resolved": "https://registry.npmjs.org/@truffle/contract/-/contract-4.2.22.tgz",
+      "integrity": "sha512-mkkuQucuZb+kHlnDwcEF5CXKa7c3hZRTN7y0NSVGlNKPMAd+VMoGi4RsJy3o0ALAumsxi714sGMHJagqoz/RmA==",
+      "dev": true,
       "requires": {
-        "@truffle/blockchain-utils": "^0.0.22",
-        "@truffle/contract-schema": "^3.2.3",
-        "@truffle/debug-utils": "^4.2.1",
-        "@truffle/error": "^0.0.8",
-        "@truffle/interface-adapter": "^0.4.13",
+        "@truffle/blockchain-utils": "^0.0.25",
+        "@truffle/contract-schema": "^3.2.5",
+        "@truffle/debug-utils": "^4.2.8",
+        "@truffle/error": "^0.0.11",
+        "@truffle/interface-adapter": "^0.4.16",
         "bignumber.js": "^7.2.1",
         "ethereum-ens": "^0.8.0",
         "ethers": "^4.0.0-beta.1",
@@ -1777,30 +2500,55 @@
         "web3-utils": "1.2.1"
       },
       "dependencies": {
+        "@truffle/contract-schema": {
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/@truffle/contract-schema/-/contract-schema-3.2.5.tgz",
+          "integrity": "sha512-07lzyYJinGvpaKc/WUm1sigtE5qDjFfUb/wUfV5cNsUmRSd/Ji9vTZ+of/zYP4MztJQLT/ZtuG836oXhWgqntg==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.10.0",
+            "crypto-js": "^3.1.9-1",
+            "debug": "^4.1.0"
+          }
+        },
         "@truffle/error": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/@truffle/error/-/error-0.0.8.tgz",
-          "integrity": "sha512-x55rtRuNfRO1azmZ30iR0pf0OJ6flQqbax1hJz+Avk1K5fdmOv5cr22s9qFnwTWnS6Bw0jvJEoR0ITsM7cPKtQ=="
+          "version": "0.0.11",
+          "resolved": "https://registry.npmjs.org/@truffle/error/-/error-0.0.11.tgz",
+          "integrity": "sha512-ju6TucjlJkfYMmdraYY/IBJaFb+Sa+huhYtOoyOJ+G29KcgytUVnDzKGwC7Kgk6IsxQMm62Mc1E0GZzFbGGipw==",
+          "dev": true
         },
         "@types/node": {
-          "version": "10.17.28",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.28.tgz",
-          "integrity": "sha512-dzjES1Egb4c1a89C7lKwQh8pwjYmlOAG9dW1pBgxEk57tMrLnssOfEthz8kdkNaBd7lIqQx7APm5+mZ619IiCQ=="
+          "version": "10.17.35",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.35.tgz",
+          "integrity": "sha512-gXx7jAWpMddu0f7a+L+txMplp3FnHl53OhQIF9puXKq3hDGY/GjH+MF04oWnV/adPSCrbtHumDCFwzq2VhltWA==",
+          "dev": true
         },
         "bignumber.js": {
           "version": "7.2.1",
           "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
-          "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
+          "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ==",
+          "dev": true
         },
         "bn.js": {
           "version": "4.11.8",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
         },
         "eth-lib": {
           "version": "0.2.7",
           "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
           "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "dev": true,
           "requires": {
             "bn.js": "^4.11.6",
             "elliptic": "^6.4.0",
@@ -1811,40 +2559,53 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
           "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "dev": true,
           "requires": {
             "inherits": "^2.0.3",
             "minimalistic-assert": "^1.0.0"
           }
         },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
         "scrypt-js": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
-          "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q="
+          "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q=",
+          "dev": true
         },
         "semver": {
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.2.0.tgz",
-          "integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A=="
+          "integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A==",
+          "dev": true
         },
         "setimmediate": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
-          "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48="
+          "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48=",
+          "dev": true
         },
         "underscore": {
           "version": "1.9.1",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
-          "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
+          "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==",
+          "dev": true
         },
         "uuid": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
-          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
+          "dev": true
         },
         "web3": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/web3/-/web3-1.2.1.tgz",
           "integrity": "sha512-nNMzeCK0agb5i/oTWNdQ1aGtwYfXzHottFP2Dz0oGIzavPMGSKyVlr8ibVb1yK5sJBjrWVnTdGaOC2zKDFuFRw==",
+          "dev": true,
           "requires": {
             "web3-bzz": "1.2.1",
             "web3-core": "1.2.1",
@@ -1859,6 +2620,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.1.tgz",
           "integrity": "sha512-LdOO44TuYbGIPfL4ilkuS89GQovxUpmLz6C1UC7VYVVRILeZS740FVB3j9V4P4FHUk1RenaDfKhcntqgVCHtjw==",
+          "dev": true,
           "requires": {
             "got": "9.6.0",
             "swarm-js": "0.1.39",
@@ -1869,6 +2631,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.1.tgz",
           "integrity": "sha512-5ODwIqgl8oIg/0+Ai4jsLxkKFWJYE0uLuE1yUKHNVCL4zL6n3rFjRMpKPokd6id6nJCNgeA64KdWQ4XfpnjdMg==",
+          "dev": true,
           "requires": {
             "web3-core-helpers": "1.2.1",
             "web3-core-method": "1.2.1",
@@ -1880,6 +2643,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.1.tgz",
           "integrity": "sha512-Gx3sTEajD5r96bJgfuW377PZVFmXIH4TdqDhgGwd2lZQCcMi+DA4TgxJNJGxn0R3aUVzyyE76j4LBrh412mXrw==",
+          "dev": true,
           "requires": {
             "underscore": "1.9.1",
             "web3-eth-iban": "1.2.1",
@@ -1890,6 +2654,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.1.tgz",
           "integrity": "sha512-Ghg2WS23qi6Xj8Od3VCzaImLHseEA7/usvnOItluiIc5cKs00WYWsNy2YRStzU9a2+z8lwQywPYp0nTzR/QXdQ==",
+          "dev": true,
           "requires": {
             "underscore": "1.9.1",
             "web3-core-helpers": "1.2.1",
@@ -1902,6 +2667,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.1.tgz",
           "integrity": "sha512-IVUqgpIKoeOYblwpex4Hye6npM0aMR+kU49VP06secPeN0rHMyhGF0ZGveWBrGvf8WDPI7jhqPBFIC6Jf3Q3zw==",
+          "dev": true,
           "requires": {
             "any-promise": "1.3.0",
             "eventemitter3": "3.1.2"
@@ -1911,6 +2677,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.1.tgz",
           "integrity": "sha512-xfknTC69RfYmLKC+83Jz73IC3/sS2ZLhGtX33D4Q5nQ8yc39ElyAolxr9sJQS8kihOcM6u4J+8gyGMqsLcpIBg==",
+          "dev": true,
           "requires": {
             "underscore": "1.9.1",
             "web3-core-helpers": "1.2.1",
@@ -1923,6 +2690,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.1.tgz",
           "integrity": "sha512-nmOwe3NsB8V8UFsY1r+sW6KjdOS68h8nuh7NzlWxBQT/19QSUGiERRTaZXWu5BYvo1EoZRMxCKyCQpSSXLc08g==",
+          "dev": true,
           "requires": {
             "eventemitter3": "3.1.2",
             "underscore": "1.9.1",
@@ -1933,6 +2701,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.1.tgz",
           "integrity": "sha512-/2xly4Yry5FW1i+uygPjhfvgUP/MS/Dk+PDqmzp5M88tS86A+j8BzKc23GrlA8sgGs0645cpZK/999LpEF5UdA==",
+          "dev": true,
           "requires": {
             "underscore": "1.9.1",
             "web3-core": "1.2.1",
@@ -1953,6 +2722,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.1.tgz",
           "integrity": "sha512-jI/KhU2a/DQPZXHjo2GW0myEljzfiKOn+h1qxK1+Y9OQfTcBMxrQJyH5AP89O6l6NZ1QvNdq99ThAxBFoy5L+g==",
+          "dev": true,
           "requires": {
             "ethers": "4.0.0-beta.3",
             "underscore": "1.9.1",
@@ -1963,6 +2733,7 @@
               "version": "6.3.3",
               "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
               "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
+              "dev": true,
               "requires": {
                 "bn.js": "^4.4.0",
                 "brorand": "^1.0.1",
@@ -1974,6 +2745,7 @@
               "version": "4.0.0-beta.3",
               "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.0-beta.3.tgz",
               "integrity": "sha512-YYPogooSknTwvHg3+Mv71gM/3Wcrx+ZpCzarBj3mqs9njjRkrOo2/eufzhHloOCo3JSoNI4TQJJ6yU5ABm3Uog==",
+              "dev": true,
               "requires": {
                 "@types/node": "^10.3.2",
                 "aes-js": "3.0.0",
@@ -1993,6 +2765,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.1.tgz",
           "integrity": "sha512-26I4qq42STQ8IeKUyur3MdQ1NzrzCqPsmzqpux0j6X/XBD7EjZ+Cs0lhGNkSKH5dI3V8CJasnQ5T1mNKeWB7nQ==",
+          "dev": true,
           "requires": {
             "any-promise": "1.3.0",
             "crypto-browserify": "3.12.0",
@@ -2010,7 +2783,8 @@
             "uuid": {
               "version": "3.3.2",
               "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-              "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+              "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+              "dev": true
             }
           }
         },
@@ -2018,6 +2792,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.1.tgz",
           "integrity": "sha512-kYFESbQ3boC9bl2rYVghj7O8UKMiuKaiMkxvRH5cEDHil8V7MGEGZNH0slSdoyeftZVlaWSMqkRP/chfnKND0g==",
+          "dev": true,
           "requires": {
             "underscore": "1.9.1",
             "web3-core": "1.2.1",
@@ -2033,6 +2808,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.1.tgz",
           "integrity": "sha512-lhP1kFhqZr2nnbu3CGIFFrAnNxk2veXpOXBY48Tub37RtobDyHijHgrj+xTh+mFiPokyrapVjpFsbGa+Xzye4Q==",
+          "dev": true,
           "requires": {
             "eth-ens-namehash": "2.0.8",
             "underscore": "1.9.1",
@@ -2048,6 +2824,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.1.tgz",
           "integrity": "sha512-9gkr4QPl1jCU+wkgmZ8EwODVO3ovVj6d6JKMos52ggdT2YCmlfvFVF6wlGLwi0VvNa/p+0BjJzaqxnnG/JewjQ==",
+          "dev": true,
           "requires": {
             "bn.js": "4.11.8",
             "web3-utils": "1.2.1"
@@ -2057,6 +2834,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.1.tgz",
           "integrity": "sha512-RNDVSiaSoY4aIp8+Hc7z+X72H7lMb3fmAChuSBADoEc7DsJrY/d0R5qQDK9g9t2BO8oxgLrLNyBP/9ub2Hc6Bg==",
+          "dev": true,
           "requires": {
             "web3-core": "1.2.1",
             "web3-core-helpers": "1.2.1",
@@ -2069,6 +2847,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.1.tgz",
           "integrity": "sha512-Yt1Bs7WgnLESPe0rri/ZoPWzSy55ovioaP35w1KZydrNtQ5Yq4WcrAdhBzcOW7vAkIwrsLQsvA+hrOCy7mNauw==",
+          "dev": true,
           "requires": {
             "web3-core": "1.2.1",
             "web3-core-method": "1.2.1",
@@ -2079,6 +2858,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.1.tgz",
           "integrity": "sha512-BDtVUVolT9b3CAzeGVA/np1hhn7RPUZ6YYGB/sYky+GjeO311Yoq8SRDUSezU92x8yImSC2B+SMReGhd1zL+bQ==",
+          "dev": true,
           "requires": {
             "web3-core-helpers": "1.2.1",
             "xhr2-cookies": "1.1.0"
@@ -2088,6 +2868,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.1.tgz",
           "integrity": "sha512-oPEuOCwxVx8L4CPD0TUdnlOUZwGBSRKScCz/Ws2YHdr9Ium+whm+0NLmOZjkjQp5wovQbyBzNa6zJz1noFRvFA==",
+          "dev": true,
           "requires": {
             "oboe": "2.1.4",
             "underscore": "1.9.1",
@@ -2098,6 +2879,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.1.tgz",
           "integrity": "sha512-oqsQXzu+ejJACVHy864WwIyw+oB21nw/pI65/sD95Zi98+/HQzFfNcIFneF1NC4bVF3VNX4YHTNq2I2o97LAiA==",
+          "dev": true,
           "requires": {
             "underscore": "1.9.1",
             "web3-core-helpers": "1.2.1",
@@ -2108,6 +2890,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.1.tgz",
           "integrity": "sha512-/3Cl04nza5kuFn25bV3FJWa0s3Vafr5BlT933h26xovQ6HIIz61LmvNQlvX1AhFL+SNJOTcQmK1SM59vcyC8bA==",
+          "dev": true,
           "requires": {
             "web3-core": "1.2.1",
             "web3-core-method": "1.2.1",
@@ -2119,6 +2902,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
           "integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+          "dev": true,
           "requires": {
             "bn.js": "4.11.8",
             "eth-lib": "0.2.7",
@@ -2135,6 +2919,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/@truffle/contract-schema/-/contract-schema-3.2.3.tgz",
       "integrity": "sha512-dnR5wtqCBKVfJDX5g+sCUiDF1WDucpxoWsr6ZOwq9JqgyS4Gz7iJi1wMegMmcDctOykoKjsju6iAOi+HObrkfg==",
+      "dev": true,
       "requires": {
         "ajv": "^6.10.0",
         "crypto-js": "^3.1.9-1",
@@ -2145,6 +2930,7 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -2152,36 +2938,39 @@
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
         }
       }
     },
     "@truffle/debug-utils": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@truffle/debug-utils/-/debug-utils-4.2.1.tgz",
-      "integrity": "sha512-OKy9dzCbbx0G1t7xfYyi2VvP+kM6gnJRPt8cjphio2vdZGuy3sB3PjL+8ILsHWyOeFluNJp+rFdAQWjjspEb9A==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@truffle/debug-utils/-/debug-utils-4.2.8.tgz",
+      "integrity": "sha512-o1apbR4FpQDVNCtT7nnXDAmHKGHEOVGuXyz9QG/IhjRdqxwZEE0pzBAW13tdIwduNaj6TQQVTB/Fx8uz914qzg==",
+      "dev": true,
       "requires": {
-        "@truffle/codec": "^0.5.9",
+        "@truffle/codec": "^0.6.1",
         "@trufflesuite/chromafi": "^2.1.2",
         "chalk": "^2.4.2",
         "debug": "^4.1.0",
         "highlight.js": "^9.15.8",
-        "highlightjs-solidity": "^1.0.17",
-        "node-dir": "0.1.17"
+        "highlightjs-solidity": "^1.0.18"
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+          "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
         }
       }
     },
@@ -2196,11 +2985,11 @@
       "integrity": "sha512-iLRALoFphCCA2ygDjyG+633dCMp81i09+V/oMDkdvDdYDF6KHjSt3Ov9eZMDnzl5PVBvmf2221U4qXSFB8V4fg=="
     },
     "@truffle/hdwallet-provider": {
-      "version": "1.0.40",
-      "resolved": "https://registry.npmjs.org/@truffle/hdwallet-provider/-/hdwallet-provider-1.0.40.tgz",
-      "integrity": "sha512-6SCzccdiFnlTREeVrGgd+ViVZCLFzrOYEIF/4qyzH2L6ilq/Taps5txKsd+/j8Jzz67ZRAB6utKxwBDv2wfW3A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@truffle/hdwallet-provider/-/hdwallet-provider-1.1.0.tgz",
+      "integrity": "sha512-hblrGs0w/S8Ij7BrmUju6GEK35NWQs2Hxc6SMBrz4chlwd9vcBzMWCGoCtYwYOi2d6o9jOv17+bLk9KNlTZR8g==",
       "requires": {
-        "@trufflesuite/web3-provider-engine": "15.0.13-0",
+        "@trufflesuite/web3-provider-engine": "15.0.13-1",
         "@types/web3": "^1.0.20",
         "any-promise": "^1.3.0",
         "bindings": "^1.5.0",
@@ -2245,9 +3034,9 @@
       }
     },
     "@truffle/interface-adapter": {
-      "version": "0.4.13",
-      "resolved": "https://registry.npmjs.org/@truffle/interface-adapter/-/interface-adapter-0.4.13.tgz",
-      "integrity": "sha512-N4TDtTvDan8Zo1csU2Otk2t0O7nOi7UP4dCfpDB5WVnD/7B07iT2getU3iRmLm4ZgwUY8VxHgDptdP55ACWCRg==",
+      "version": "0.4.16",
+      "resolved": "https://registry.npmjs.org/@truffle/interface-adapter/-/interface-adapter-0.4.16.tgz",
+      "integrity": "sha512-lsxk26Lz/h0n8fe37K1ZxowxokXj0AZeNR10QHltDvkHukuTIC4L6fXvrUi74mCwI9hShl4CSBas1Q8kAyJyOA==",
       "requires": {
         "bn.js": "^4.11.8",
         "ethers": "^4.0.32",
@@ -2256,9 +3045,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.28",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.28.tgz",
-          "integrity": "sha512-dzjES1Egb4c1a89C7lKwQh8pwjYmlOAG9dW1pBgxEk57tMrLnssOfEthz8kdkNaBd7lIqQx7APm5+mZ619IiCQ=="
+          "version": "10.17.35",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.35.tgz",
+          "integrity": "sha512-gXx7jAWpMddu0f7a+L+txMplp3FnHl53OhQIF9puXKq3hDGY/GjH+MF04oWnV/adPSCrbtHumDCFwzq2VhltWA=="
         },
         "eth-lib": {
           "version": "0.2.7",
@@ -2629,6 +3418,92 @@
         "supports-color": "^7.1.0"
       },
       "dependencies": {
+        "@truffle/blockchain-utils": {
+          "version": "0.0.25",
+          "resolved": "https://registry.npmjs.org/@truffle/blockchain-utils/-/blockchain-utils-0.0.25.tgz",
+          "integrity": "sha512-XA5m0BfAWtysy5ChHyiAf1fXbJxJXphKk+eZ9Rb9Twi6fn3Jg4gnHNwYXJacYFEydqT5vr2s4Ou812JHlautpw==",
+          "requires": {
+            "source-map-support": "^0.5.19"
+          }
+        },
+        "@truffle/codec": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/@truffle/codec/-/codec-0.6.1.tgz",
+          "integrity": "sha512-HrInHX9yLVVRCGOsXG2mZNG5P724KHZH3Pez6tMn39yLPsiKm9CzHcAHF5uX7ExhponOTEtKViudQ4MAFfh9Jg==",
+          "requires": {
+            "big.js": "^5.2.2",
+            "bn.js": "^4.11.8",
+            "borc": "^2.1.2",
+            "debug": "^4.1.0",
+            "lodash.clonedeep": "^4.5.0",
+            "lodash.escaperegexp": "^4.1.2",
+            "lodash.partition": "^4.6.0",
+            "lodash.sum": "^4.0.2",
+            "semver": "^6.3.0",
+            "source-map-support": "^0.5.19",
+            "utf8": "^3.0.0",
+            "web3-utils": "1.2.1"
+          }
+        },
+        "@truffle/contract": {
+          "version": "4.2.22",
+          "resolved": "https://registry.npmjs.org/@truffle/contract/-/contract-4.2.22.tgz",
+          "integrity": "sha512-mkkuQucuZb+kHlnDwcEF5CXKa7c3hZRTN7y0NSVGlNKPMAd+VMoGi4RsJy3o0ALAumsxi714sGMHJagqoz/RmA==",
+          "requires": {
+            "@truffle/blockchain-utils": "^0.0.25",
+            "@truffle/contract-schema": "^3.2.5",
+            "@truffle/debug-utils": "^4.2.8",
+            "@truffle/error": "^0.0.11",
+            "@truffle/interface-adapter": "^0.4.16",
+            "bignumber.js": "^7.2.1",
+            "ethereum-ens": "^0.8.0",
+            "ethers": "^4.0.0-beta.1",
+            "source-map-support": "^0.5.19",
+            "web3": "1.2.1",
+            "web3-core-helpers": "1.2.1",
+            "web3-core-promievent": "1.2.1",
+            "web3-eth-abi": "1.2.1",
+            "web3-utils": "1.2.1"
+          }
+        },
+        "@truffle/contract-schema": {
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/@truffle/contract-schema/-/contract-schema-3.2.5.tgz",
+          "integrity": "sha512-07lzyYJinGvpaKc/WUm1sigtE5qDjFfUb/wUfV5cNsUmRSd/Ji9vTZ+of/zYP4MztJQLT/ZtuG836oXhWgqntg==",
+          "requires": {
+            "ajv": "^6.10.0",
+            "crypto-js": "^3.1.9-1",
+            "debug": "^4.1.0"
+          }
+        },
+        "@truffle/debug-utils": {
+          "version": "4.2.8",
+          "resolved": "https://registry.npmjs.org/@truffle/debug-utils/-/debug-utils-4.2.8.tgz",
+          "integrity": "sha512-o1apbR4FpQDVNCtT7nnXDAmHKGHEOVGuXyz9QG/IhjRdqxwZEE0pzBAW13tdIwduNaj6TQQVTB/Fx8uz914qzg==",
+          "requires": {
+            "@truffle/codec": "^0.6.1",
+            "@trufflesuite/chromafi": "^2.1.2",
+            "chalk": "^2.4.2",
+            "debug": "^4.1.0",
+            "highlight.js": "^9.15.8",
+            "highlightjs-solidity": "^1.0.18"
+          }
+        },
+        "@truffle/error": {
+          "version": "0.0.11",
+          "resolved": "https://registry.npmjs.org/@truffle/error/-/error-0.0.11.tgz",
+          "integrity": "sha512-ju6TucjlJkfYMmdraYY/IBJaFb+Sa+huhYtOoyOJ+G29KcgytUVnDzKGwC7Kgk6IsxQMm62Mc1E0GZzFbGGipw=="
+        },
+        "@types/node": {
+          "version": "10.17.35",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.35.tgz",
+          "integrity": "sha512-gXx7jAWpMddu0f7a+L+txMplp3FnHl53OhQIF9puXKq3hDGY/GjH+MF04oWnV/adPSCrbtHumDCFwzq2VhltWA=="
+        },
+        "bignumber.js": {
+          "version": "7.2.1",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
+          "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
+        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -2637,15 +3512,54 @@
             "ms": "^2.1.1"
           }
         },
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
+        "hash.js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "highlightjs-solidity": {
+          "version": "1.0.18",
+          "resolved": "https://registry.npmjs.org/highlightjs-solidity/-/highlightjs-solidity-1.0.18.tgz",
+          "integrity": "sha512-k15h0br4oCRT0F0jTRuZbimerVt5V4n0k25h7oWi0kVqlBNeXPbSr5ddw02/2ukJmYfB8jauFDmxSauJjwM7Eg=="
+        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "scrypt-js": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
+          "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q="
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        },
+        "setimmediate": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
+          "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48="
         },
         "supports-color": {
           "version": "7.1.0",
@@ -2653,6 +3567,323 @@
           "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
           "requires": {
             "has-flag": "^4.0.0"
+          }
+        },
+        "underscore": {
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+          "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
+        },
+        "uuid": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+        },
+        "web3": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3/-/web3-1.2.1.tgz",
+          "integrity": "sha512-nNMzeCK0agb5i/oTWNdQ1aGtwYfXzHottFP2Dz0oGIzavPMGSKyVlr8ibVb1yK5sJBjrWVnTdGaOC2zKDFuFRw==",
+          "requires": {
+            "web3-bzz": "1.2.1",
+            "web3-core": "1.2.1",
+            "web3-eth": "1.2.1",
+            "web3-eth-personal": "1.2.1",
+            "web3-net": "1.2.1",
+            "web3-shh": "1.2.1",
+            "web3-utils": "1.2.1"
+          }
+        },
+        "web3-bzz": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.1.tgz",
+          "integrity": "sha512-LdOO44TuYbGIPfL4ilkuS89GQovxUpmLz6C1UC7VYVVRILeZS740FVB3j9V4P4FHUk1RenaDfKhcntqgVCHtjw==",
+          "requires": {
+            "got": "9.6.0",
+            "swarm-js": "0.1.39",
+            "underscore": "1.9.1"
+          }
+        },
+        "web3-core": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.1.tgz",
+          "integrity": "sha512-5ODwIqgl8oIg/0+Ai4jsLxkKFWJYE0uLuE1yUKHNVCL4zL6n3rFjRMpKPokd6id6nJCNgeA64KdWQ4XfpnjdMg==",
+          "requires": {
+            "web3-core-helpers": "1.2.1",
+            "web3-core-method": "1.2.1",
+            "web3-core-requestmanager": "1.2.1",
+            "web3-utils": "1.2.1"
+          }
+        },
+        "web3-core-helpers": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.1.tgz",
+          "integrity": "sha512-Gx3sTEajD5r96bJgfuW377PZVFmXIH4TdqDhgGwd2lZQCcMi+DA4TgxJNJGxn0R3aUVzyyE76j4LBrh412mXrw==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-eth-iban": "1.2.1",
+            "web3-utils": "1.2.1"
+          }
+        },
+        "web3-core-method": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.1.tgz",
+          "integrity": "sha512-Ghg2WS23qi6Xj8Od3VCzaImLHseEA7/usvnOItluiIc5cKs00WYWsNy2YRStzU9a2+z8lwQywPYp0nTzR/QXdQ==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.1",
+            "web3-core-promievent": "1.2.1",
+            "web3-core-subscriptions": "1.2.1",
+            "web3-utils": "1.2.1"
+          }
+        },
+        "web3-core-promievent": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.1.tgz",
+          "integrity": "sha512-IVUqgpIKoeOYblwpex4Hye6npM0aMR+kU49VP06secPeN0rHMyhGF0ZGveWBrGvf8WDPI7jhqPBFIC6Jf3Q3zw==",
+          "requires": {
+            "any-promise": "1.3.0",
+            "eventemitter3": "3.1.2"
+          }
+        },
+        "web3-core-requestmanager": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.1.tgz",
+          "integrity": "sha512-xfknTC69RfYmLKC+83Jz73IC3/sS2ZLhGtX33D4Q5nQ8yc39ElyAolxr9sJQS8kihOcM6u4J+8gyGMqsLcpIBg==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.1",
+            "web3-providers-http": "1.2.1",
+            "web3-providers-ipc": "1.2.1",
+            "web3-providers-ws": "1.2.1"
+          }
+        },
+        "web3-core-subscriptions": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.1.tgz",
+          "integrity": "sha512-nmOwe3NsB8V8UFsY1r+sW6KjdOS68h8nuh7NzlWxBQT/19QSUGiERRTaZXWu5BYvo1EoZRMxCKyCQpSSXLc08g==",
+          "requires": {
+            "eventemitter3": "3.1.2",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.1"
+          }
+        },
+        "web3-eth": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.1.tgz",
+          "integrity": "sha512-/2xly4Yry5FW1i+uygPjhfvgUP/MS/Dk+PDqmzp5M88tS86A+j8BzKc23GrlA8sgGs0645cpZK/999LpEF5UdA==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core": "1.2.1",
+            "web3-core-helpers": "1.2.1",
+            "web3-core-method": "1.2.1",
+            "web3-core-subscriptions": "1.2.1",
+            "web3-eth-abi": "1.2.1",
+            "web3-eth-accounts": "1.2.1",
+            "web3-eth-contract": "1.2.1",
+            "web3-eth-ens": "1.2.1",
+            "web3-eth-iban": "1.2.1",
+            "web3-eth-personal": "1.2.1",
+            "web3-net": "1.2.1",
+            "web3-utils": "1.2.1"
+          }
+        },
+        "web3-eth-abi": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.1.tgz",
+          "integrity": "sha512-jI/KhU2a/DQPZXHjo2GW0myEljzfiKOn+h1qxK1+Y9OQfTcBMxrQJyH5AP89O6l6NZ1QvNdq99ThAxBFoy5L+g==",
+          "requires": {
+            "ethers": "4.0.0-beta.3",
+            "underscore": "1.9.1",
+            "web3-utils": "1.2.1"
+          },
+          "dependencies": {
+            "elliptic": {
+              "version": "6.3.3",
+              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
+              "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
+              "requires": {
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "inherits": "^2.0.1"
+              }
+            },
+            "ethers": {
+              "version": "4.0.0-beta.3",
+              "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.0-beta.3.tgz",
+              "integrity": "sha512-YYPogooSknTwvHg3+Mv71gM/3Wcrx+ZpCzarBj3mqs9njjRkrOo2/eufzhHloOCo3JSoNI4TQJJ6yU5ABm3Uog==",
+              "requires": {
+                "@types/node": "^10.3.2",
+                "aes-js": "3.0.0",
+                "bn.js": "^4.4.0",
+                "elliptic": "6.3.3",
+                "hash.js": "1.1.3",
+                "js-sha3": "0.5.7",
+                "scrypt-js": "2.0.3",
+                "setimmediate": "1.0.4",
+                "uuid": "2.0.1",
+                "xmlhttprequest": "1.8.0"
+              }
+            }
+          }
+        },
+        "web3-eth-accounts": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.1.tgz",
+          "integrity": "sha512-26I4qq42STQ8IeKUyur3MdQ1NzrzCqPsmzqpux0j6X/XBD7EjZ+Cs0lhGNkSKH5dI3V8CJasnQ5T1mNKeWB7nQ==",
+          "requires": {
+            "any-promise": "1.3.0",
+            "crypto-browserify": "3.12.0",
+            "eth-lib": "0.2.7",
+            "scryptsy": "2.1.0",
+            "semver": "6.2.0",
+            "underscore": "1.9.1",
+            "uuid": "3.3.2",
+            "web3-core": "1.2.1",
+            "web3-core-helpers": "1.2.1",
+            "web3-core-method": "1.2.1",
+            "web3-utils": "1.2.1"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "6.2.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.2.0.tgz",
+              "integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A=="
+            },
+            "uuid": {
+              "version": "3.3.2",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+              "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+            }
+          }
+        },
+        "web3-eth-contract": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.1.tgz",
+          "integrity": "sha512-kYFESbQ3boC9bl2rYVghj7O8UKMiuKaiMkxvRH5cEDHil8V7MGEGZNH0slSdoyeftZVlaWSMqkRP/chfnKND0g==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core": "1.2.1",
+            "web3-core-helpers": "1.2.1",
+            "web3-core-method": "1.2.1",
+            "web3-core-promievent": "1.2.1",
+            "web3-core-subscriptions": "1.2.1",
+            "web3-eth-abi": "1.2.1",
+            "web3-utils": "1.2.1"
+          }
+        },
+        "web3-eth-ens": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.1.tgz",
+          "integrity": "sha512-lhP1kFhqZr2nnbu3CGIFFrAnNxk2veXpOXBY48Tub37RtobDyHijHgrj+xTh+mFiPokyrapVjpFsbGa+Xzye4Q==",
+          "requires": {
+            "eth-ens-namehash": "2.0.8",
+            "underscore": "1.9.1",
+            "web3-core": "1.2.1",
+            "web3-core-helpers": "1.2.1",
+            "web3-core-promievent": "1.2.1",
+            "web3-eth-abi": "1.2.1",
+            "web3-eth-contract": "1.2.1",
+            "web3-utils": "1.2.1"
+          }
+        },
+        "web3-eth-iban": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.1.tgz",
+          "integrity": "sha512-9gkr4QPl1jCU+wkgmZ8EwODVO3ovVj6d6JKMos52ggdT2YCmlfvFVF6wlGLwi0VvNa/p+0BjJzaqxnnG/JewjQ==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "web3-utils": "1.2.1"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.8",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+              "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+            }
+          }
+        },
+        "web3-eth-personal": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.1.tgz",
+          "integrity": "sha512-RNDVSiaSoY4aIp8+Hc7z+X72H7lMb3fmAChuSBADoEc7DsJrY/d0R5qQDK9g9t2BO8oxgLrLNyBP/9ub2Hc6Bg==",
+          "requires": {
+            "web3-core": "1.2.1",
+            "web3-core-helpers": "1.2.1",
+            "web3-core-method": "1.2.1",
+            "web3-net": "1.2.1",
+            "web3-utils": "1.2.1"
+          }
+        },
+        "web3-net": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.1.tgz",
+          "integrity": "sha512-Yt1Bs7WgnLESPe0rri/ZoPWzSy55ovioaP35w1KZydrNtQ5Yq4WcrAdhBzcOW7vAkIwrsLQsvA+hrOCy7mNauw==",
+          "requires": {
+            "web3-core": "1.2.1",
+            "web3-core-method": "1.2.1",
+            "web3-utils": "1.2.1"
+          }
+        },
+        "web3-providers-http": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.1.tgz",
+          "integrity": "sha512-BDtVUVolT9b3CAzeGVA/np1hhn7RPUZ6YYGB/sYky+GjeO311Yoq8SRDUSezU92x8yImSC2B+SMReGhd1zL+bQ==",
+          "requires": {
+            "web3-core-helpers": "1.2.1",
+            "xhr2-cookies": "1.1.0"
+          }
+        },
+        "web3-providers-ipc": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.1.tgz",
+          "integrity": "sha512-oPEuOCwxVx8L4CPD0TUdnlOUZwGBSRKScCz/Ws2YHdr9Ium+whm+0NLmOZjkjQp5wovQbyBzNa6zJz1noFRvFA==",
+          "requires": {
+            "oboe": "2.1.4",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.1"
+          }
+        },
+        "web3-providers-ws": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.1.tgz",
+          "integrity": "sha512-oqsQXzu+ejJACVHy864WwIyw+oB21nw/pI65/sD95Zi98+/HQzFfNcIFneF1NC4bVF3VNX4YHTNq2I2o97LAiA==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.1",
+            "websocket": "github:web3-js/WebSocket-Node#polyfill/globalThis"
+          }
+        },
+        "web3-shh": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.1.tgz",
+          "integrity": "sha512-/3Cl04nza5kuFn25bV3FJWa0s3Vafr5BlT933h26xovQ6HIIz61LmvNQlvX1AhFL+SNJOTcQmK1SM59vcyC8bA==",
+          "requires": {
+            "web3-core": "1.2.1",
+            "web3-core-method": "1.2.1",
+            "web3-core-subscriptions": "1.2.1",
+            "web3-net": "1.2.1"
+          }
+        },
+        "web3-utils": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
+          "integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randomhex": "0.1.5",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.8",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+              "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+            }
           }
         }
       }
@@ -2705,6 +3936,27 @@
         "json-rpc-engine": "^5.1.3",
         "lodash.flatmap": "^4.5.0",
         "safe-event-emitter": "^1.0.1"
+      }
+    },
+    "@trufflesuite/eth-json-rpc-infura": {
+      "version": "4.0.3-0",
+      "resolved": "https://registry.npmjs.org/@trufflesuite/eth-json-rpc-infura/-/eth-json-rpc-infura-4.0.3-0.tgz",
+      "integrity": "sha512-xaUanOmo0YLqRsL0SfXpFienhdw5bpQ1WEXxMTRi57az4lwpZBv4tFUDvcerdwJrxX9wQqNmgUgd1BrR01dumw==",
+      "requires": {
+        "@trufflesuite/eth-json-rpc-middleware": "^4.4.2-1",
+        "cross-fetch": "^2.1.1",
+        "eth-json-rpc-errors": "^1.0.1",
+        "json-rpc-engine": "^5.1.3"
+      },
+      "dependencies": {
+        "eth-json-rpc-errors": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/eth-json-rpc-errors/-/eth-json-rpc-errors-1.1.1.tgz",
+          "integrity": "sha512-WT5shJ5KfNqHi9jOZD+ID8I1kuYWNrigtZat7GOQkvwo99f8SzAVaEcWhJUv656WiZOAg3P1RiJQANtUmDmbIg==",
+          "requires": {
+            "fast-safe-stringify": "^2.0.6"
+          }
+        }
       }
     },
     "@trufflesuite/eth-json-rpc-middleware": {
@@ -2792,11 +4044,12 @@
       }
     },
     "@trufflesuite/web3-provider-engine": {
-      "version": "15.0.13-0",
-      "resolved": "https://registry.npmjs.org/@trufflesuite/web3-provider-engine/-/web3-provider-engine-15.0.13-0.tgz",
-      "integrity": "sha512-bgGE2Sg56XMu0dhJl7UMiFfEFSvxW47G0RCQ3schV2kUilLKeqvGHE9z1ElVi8W30F/pF7VDbp5DkprvFC9+HQ==",
+      "version": "15.0.13-1",
+      "resolved": "https://registry.npmjs.org/@trufflesuite/web3-provider-engine/-/web3-provider-engine-15.0.13-1.tgz",
+      "integrity": "sha512-6u3x/iIN5fyj8pib5QTUDmIOUiwAGhaqdSTXdqCu6v9zo2BEwdCqgEJd1uXDh3DBmPRDfiZ/ge8oUPy7LerpHg==",
       "requires": {
         "@trufflesuite/eth-json-rpc-filters": "^4.1.2-1",
+        "@trufflesuite/eth-json-rpc-infura": "^4.0.3-0",
         "@trufflesuite/eth-json-rpc-middleware": "^4.4.2-1",
         "@trufflesuite/eth-sig-util": "^1.4.2",
         "async": "^2.5.0",
@@ -2805,7 +4058,6 @@
         "cross-fetch": "^2.1.0",
         "eth-block-tracker": "^4.4.2",
         "eth-json-rpc-errors": "^2.0.2",
-        "eth-json-rpc-infura": "^4.0.1",
         "ethereumjs-block": "^1.2.2",
         "ethereumjs-tx": "^1.2.0",
         "ethereumjs-util": "^5.1.5",
@@ -3280,9 +4532,9 @@
       }
     },
     "bl": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-      "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
+      "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
       "requires": {
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
@@ -3390,6 +4642,27 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+    },
+    "borc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/borc/-/borc-2.1.2.tgz",
+      "integrity": "sha512-Sy9eoUi4OiKzq7VovMn246iTo17kzuyHJKomCfpWMlI6RpfN1gk95w7d7gH264nApVLg0HZfcpz62/g4VH1Y4w==",
+      "requires": {
+        "bignumber.js": "^9.0.0",
+        "buffer": "^5.5.0",
+        "commander": "^2.15.0",
+        "ieee754": "^1.1.13",
+        "iso-url": "~0.4.7",
+        "json-text-sequence": "~0.1.0",
+        "readable-stream": "^3.6.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+        }
+      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -4321,9 +5594,9 @@
       }
     },
     "dot-prop": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
-      "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
+      "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
       "requires": {
         "is-obj": "^1.0.0"
       }
@@ -4525,36 +5798,81 @@
       }
     },
     "eth-json-rpc-filters": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/eth-json-rpc-filters/-/eth-json-rpc-filters-4.1.1.tgz",
-      "integrity": "sha512-GkXb2h6STznD+AmMzblwXgm1JMvjdK9PTIXG7BvIkTlXQ9g0QOxuU1iQRYHoslF9S30BYBSoLSisAYPdLggW+A==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eth-json-rpc-filters/-/eth-json-rpc-filters-4.2.1.tgz",
+      "integrity": "sha512-tPfohezq8mSmwa47xvq6PGzBDLZ0njWJMB1J+OPuv+n+1WkWDlf3l3tqJXpq96RxhrzK2q7wiweRS5aGIzpq4Q==",
       "requires": {
         "await-semaphore": "^0.1.3",
-        "eth-json-rpc-middleware": "^4.1.4",
+        "eth-json-rpc-middleware": "^6.0.0",
         "eth-query": "^2.1.2",
-        "json-rpc-engine": "^5.1.3",
+        "json-rpc-engine": "^5.3.0",
         "lodash.flatmap": "^4.5.0",
         "safe-event-emitter": "^1.0.1"
+      },
+      "dependencies": {
+        "eth-json-rpc-middleware": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/eth-json-rpc-middleware/-/eth-json-rpc-middleware-6.0.0.tgz",
+          "integrity": "sha512-qqBfLU2Uq1Ou15Wox1s+NX05S9OcAEL4JZ04VZox2NS0U+RtCMjSxzXhLFWekdShUPZ+P8ax3zCO2xcPrp6XJQ==",
+          "requires": {
+            "btoa": "^1.2.1",
+            "clone": "^2.1.1",
+            "eth-query": "^2.1.2",
+            "eth-rpc-errors": "^3.0.0",
+            "eth-sig-util": "^1.4.2",
+            "ethereumjs-util": "^5.1.2",
+            "json-rpc-engine": "^5.3.0",
+            "json-stable-stringify": "^1.0.1",
+            "node-fetch": "^2.6.1",
+            "pify": "^3.0.0",
+            "safe-event-emitter": "^1.0.1"
+          }
+        },
+        "ethereumjs-util": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+          "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "elliptic": "^6.5.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "^0.1.3",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1"
+          }
+        },
+        "json-rpc-engine": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-5.3.0.tgz",
+          "integrity": "sha512-+diJ9s8rxB+fbJhT7ZEf8r8spaLRignLd8jTgQ/h5JSGppAHGtNMZtCoabipCaleR1B3GTGxbXBOqhaJSGmPGQ==",
+          "requires": {
+            "eth-rpc-errors": "^3.0.0",
+            "safe-event-emitter": "^1.0.1"
+          }
+        },
+        "node-fetch": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+        }
       }
     },
     "eth-json-rpc-infura": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/eth-json-rpc-infura/-/eth-json-rpc-infura-4.0.2.tgz",
-      "integrity": "sha512-dvgOrci9lZqpjpp0hoC3Zfedhg3aIpLFVDH0TdlKxRlkhR75hTrKTwxghDrQwE0bn3eKrC8RsN1m/JdnIWltpw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eth-json-rpc-infura/-/eth-json-rpc-infura-4.1.0.tgz",
+      "integrity": "sha512-DFYitKovzVlCdUulEccdm4g6k/vnvyByuw7rd5OoWDBSIiaeinI8Z/SntLjSIs2c+YvE20DGwk/GLwZGCWDN1Q==",
       "requires": {
-        "cross-fetch": "^2.1.1",
-        "eth-json-rpc-errors": "^1.0.1",
-        "eth-json-rpc-middleware": "^4.1.4",
-        "json-rpc-engine": "^5.1.3"
+        "eth-json-rpc-middleware": "^4.4.0",
+        "eth-rpc-errors": "^3.0.0",
+        "json-rpc-engine": "^5.1.3",
+        "node-fetch": "^2.6.0"
       },
       "dependencies": {
-        "eth-json-rpc-errors": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/eth-json-rpc-errors/-/eth-json-rpc-errors-1.1.1.tgz",
-          "integrity": "sha512-WT5shJ5KfNqHi9jOZD+ID8I1kuYWNrigtZat7GOQkvwo99f8SzAVaEcWhJUv656WiZOAg3P1RiJQANtUmDmbIg==",
-          "requires": {
-            "fast-safe-stringify": "^2.0.6"
-          }
+        "node-fetch": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
         }
       }
     },
@@ -4656,6 +5974,14 @@
         "xtend": "^4.0.1"
       }
     },
+    "eth-rpc-errors": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eth-rpc-errors/-/eth-rpc-errors-3.0.0.tgz",
+      "integrity": "sha512-iPPNHPrLwUlR9xCSYm7HHQjWBasor3+KZfRvwEWxMz3ca0yqnlBeJrnyphkGIXZ4J7AMAaOLmwy4AWhnxOiLxg==",
+      "requires": {
+        "fast-safe-stringify": "^2.0.6"
+      }
+    },
     "eth-sig-util": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
@@ -4665,6 +5991,30 @@
         "ethereumjs-util": "^5.1.1"
       },
       "dependencies": {
+        "ethereumjs-abi": {
+          "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1ce6a1d64235fabe2aaf827fd606def55693508f",
+          "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+          "requires": {
+            "bn.js": "^4.11.8",
+            "ethereumjs-util": "^6.0.0"
+          },
+          "dependencies": {
+            "ethereumjs-util": {
+              "version": "6.2.1",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+              "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
+              "requires": {
+                "@types/bn.js": "^4.11.3",
+                "bn.js": "^4.11.0",
+                "create-hash": "^1.1.2",
+                "elliptic": "^6.5.2",
+                "ethereum-cryptography": "^0.1.3",
+                "ethjs-util": "0.1.6",
+                "rlp": "^2.2.3"
+              }
+            }
+          }
+        },
         "ethereumjs-util": {
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
@@ -4743,7 +6093,8 @@
     },
     "ethereumjs-abi": {
       "version": "0.6.8",
-      "resolved": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1cfbb13862f90f0b391d8a699544d5fe4dfb8c7b",
+      "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.8.tgz",
+      "integrity": "sha512-Tx0r/iXI6r+lRsdvkFDlut0N08jWMnKRZ6Gkq+Nmw75lZe4e6o3EkSnkaBP5NF6+m5PTGAr9JP43N3LyeoglsA==",
       "requires": {
         "bn.js": "^4.11.8",
         "ethereumjs-util": "^6.0.0"
@@ -4927,13 +6278,13 @@
       }
     },
     "ethers": {
-      "version": "4.0.47",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.47.tgz",
-      "integrity": "sha512-hssRYhngV4hiDNeZmVU/k5/E8xmLG8UpcNUzg6mb7lqhgpFPH/t7nuv20RjRrEf0gblzvi2XwR5Te+V3ZFc9pQ==",
+      "version": "4.0.48",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.48.tgz",
+      "integrity": "sha512-sZD5K8H28dOrcidzx9f8KYh8083n5BexIO3+SbE4jK83L85FxtpXZBCQdXb8gkg+7sBqomcLhhkU7UHL+F7I2g==",
       "requires": {
         "aes-js": "3.0.0",
         "bn.js": "^4.4.0",
-        "elliptic": "6.5.2",
+        "elliptic": "6.5.3",
         "hash.js": "1.1.3",
         "js-sha3": "0.5.7",
         "scrypt-js": "2.0.4",
@@ -4942,20 +6293,6 @@
         "xmlhttprequest": "1.8.0"
       },
       "dependencies": {
-        "elliptic": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-          "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
-          "requires": {
-            "bn.js": "^4.4.0",
-            "brorand": "^1.0.1",
-            "hash.js": "^1.0.0",
-            "hmac-drbg": "^1.0.0",
-            "inherits": "^2.0.1",
-            "minimalistic-assert": "^1.0.0",
-            "minimalistic-crypto-utils": "^1.0.0"
-          }
-        },
         "hash.js": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
@@ -8865,9 +10202,9 @@
           "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4="
         },
         "elliptic": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-          "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+          "version": "6.5.3",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+          "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
           "requires": {
             "bn.js": "^4.4.0",
             "brorand": "^1.0.1",
@@ -10327,7 +11664,6 @@
           "requires": {
             "aes-js": "3.0.0",
             "bn.js": "^4.4.0",
-            "elliptic": "6.5.2",
             "hash.js": "1.1.3",
             "js-sha3": "0.5.7",
             "scrypt-js": "2.0.4",
@@ -20102,9 +21438,10 @@
       "integrity": "sha512-OrVKYz70LHsnCgmbXctv/bfuvntIKDz177h0Co37DQ5jamGZLVmoCVMtjMtNZY3X9DrCcKfklHPNeA0uPZhSJg=="
     },
     "highlightjs-solidity": {
-      "version": "1.0.17",
-      "resolved": "https://registry.npmjs.org/highlightjs-solidity/-/highlightjs-solidity-1.0.17.tgz",
-      "integrity": "sha512-QHSoGDjsfFDBraXtHKdJj2xXlu0fpG2ycZI4woNXLOennJbER2zX5cJL8xdRKQ9kk0q76kt86NgAyMRkttfPQw=="
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/highlightjs-solidity/-/highlightjs-solidity-1.0.18.tgz",
+      "integrity": "sha512-k15h0br4oCRT0F0jTRuZbimerVt5V4n0k25h7oWi0kVqlBNeXPbSr5ddw02/2ukJmYfB8jauFDmxSauJjwM7Eg==",
+      "dev": true
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -20624,6 +21961,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
+    "iso-url": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-0.4.7.tgz",
+      "integrity": "sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog=="
     },
     "isomorphic-fetch": {
       "version": "2.2.1",
@@ -21399,14 +22741,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
       "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
-    },
-    "node-dir": {
-      "version": "0.1.17",
-      "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
-      "integrity": "sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=",
-      "requires": {
-        "minimatch": "^3.0.2"
-      }
     },
     "node-environment-flags": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "@openzeppelin/contracts": "^2.5.0",
     "@openzeppelin/contracts-ethereum-package": "^2.5.0",
     "@openzeppelin/upgrades": "^2.8.0",
-    "@truffle/contract": "^4.2.0",
-    "@truffle/hdwallet-provider": "^1.0.34",
+    "@truffle/hdwallet-provider": "^1.1.0",
     "@truffle/resolver": "^5.1.9",
     "commander": "^5.0.0",
     "decompress": "^4.2.1",
@@ -33,6 +32,7 @@
   "devDependencies": {
     "@openzeppelin/test-environment": "^0.1.3",
     "@openzeppelin/test-helpers": "^0.5.5",
+    "@truffle/contract": "^4.2.22",
     "@types/inquirer": "^6.5.0",
     "@types/node": "^14.0.13",
     "chai": "^4.2.0",

--- a/test/BlendToken.js
+++ b/test/BlendToken.js
@@ -271,7 +271,8 @@ describe('BlendToken', async function() {
 
         it('is enabled at distribution phase', async function() {
             await ctx.blend.startDistributionPhase({ from: orchestrator })
-            await ctx.blend.burn(
+            const burn = ctx.blend.methods['burn(address,uint256)']
+            await burn(
                 tenderAddress, toBN('50'), { from: orchestrator }
             )
             const remaining = await ctx.blend.balanceOf(tenderAddress)
@@ -279,8 +280,9 @@ describe('BlendToken', async function() {
         })
 
         it('is disabled at regurlar phase', async function() {
+            const burn = ctx.blend.methods['burn(address,uint256)']
             await expectRevert(
-                ctx.blend.burn(
+                burn(
                     tenderAddress, toBN('50'), { from: orchestrator }
                 ),
                 'Burn is allowed only at distribution phase'
@@ -289,18 +291,20 @@ describe('BlendToken', async function() {
 
         it('cannot burn more than the balance of tender address', async function() {
             await ctx.blend.startDistributionPhase({ from: orchestrator })
+            const burn = ctx.blend.methods['burn(address,uint256)']
             await expectRevert(
-                ctx.blend.burn(
+                burn(
                     tenderAddress, toBN('150'), { from: orchestrator }
                 ),
                 'Not enough balance on tender address'
             )
         })
 
-        it('cannot burn from a someone\'s regular address', async function() {
+        it('cannot burn from someone\'s regular address', async function() {
             await ctx.blend.startDistributionPhase({ from: orchestrator })
+            const burn = ctx.blend.methods['burn(address,uint256)']
             await expectRevert(
-                ctx.blend.burn(
+                burn(
                     alice, toBN('100'), { from: orchestrator }
                 ),
                 'Burning from regular addresses is not allowed'
@@ -311,7 +315,8 @@ describe('BlendToken', async function() {
     describe('burn from sender', async function() {
         it('should burn my tokens', async function() {
             const oldBalance = await ctx.blend.balanceOf(alice)
-            await ctx.blend.burn(toBN('22222'), { from: alice })
+            const burn = ctx.blend.methods['burn(uint256)']
+            await burn(toBN('22222'), { from: alice })
             const newBalance = await ctx.blend.balanceOf(alice)
             const balanceDelta = newBalance.sub(oldBalance)
             expect(balanceDelta).to.be.bignumber.equal(toBN('-22222'))
@@ -319,7 +324,8 @@ describe('BlendToken', async function() {
 
         it('should decrease total supply', async function() {
             const oldSupply = await ctx.blend.totalSupply()
-            await ctx.blend.burn(alice, toBN('22222'), { from: owner })
+            const burn = ctx.blend.methods['burn(uint256)']
+            await burn(toBN('22222'), { from: alice })
             const newSupply = await ctx.blend.totalSupply()
             const supplyDelta = newSupply.sub(oldSupply)
             expect(supplyDelta).to.be.bignumber.equal(toBN('-22222'))
@@ -327,9 +333,10 @@ describe('BlendToken', async function() {
 
         it('should not burn more than available', async function() {
             await ctx.blend.transfer(bob, toBN('22222'), { from: alice })
+            const burn = ctx.blend.methods['burn(uint256)']
             await expectRevert(
-                ctx.blend.burn(toBN('22223'), { from: bob }),
-                "Boom"
+                burn(toBN('22223'), { from: bob }),
+                "ERC20: burn amount exceeds balance"
             )
         })
     })
@@ -354,7 +361,7 @@ describe('BlendToken', async function() {
             await
             await expectRevert(
                 ctx.blend.mint(alice, toBN('22222'), { from: alice }),
-                "Boom"
+                "Ownable: caller is not the owner"
             )
         })
     })


### PR DESCRIPTION
Problem: The code of BlendToken.sol stopped compiling after we introduced mint & burn entrypoints. In addition to this, tests did not pass.

Solution: Add the missing parentheses to the contract, add explicit method signatures to tests, fix the expected errors.

In addition to the fix, this PR bumps the dependencies as suggested by `npm audit fix`