### PR TITLE
[SDAO-242] Add batch tender address registration

### DIFF
--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -184,6 +184,24 @@ contract Registry is Initializable, Ownable {
         _tenderAddresses[tenderAddress] = true;
     }
 
+    /// @notice Adds a batch of addresses to the set of registered
+    ///         tender addresses
+    /// @param tenderAddresses A batch of tender addresses to register
+    function registerTenderAddressBatch(address[] memory tenderAddresses)
+        public
+        onlyBackend
+    {
+        uint len = tenderAddresses.length;
+        for (uint i = 0; i < len; ++i) {
+            address tenderAddress = tenderAddresses[i];
+            require(
+                _tenderAddresses[tenderAddress] == false,
+                "Tender address already registered"
+            );
+            _tenderAddresses[tenderAddress] = true;
+        }
+    }
+
     /// @notice Returns whether `tenderAddress` was registered by
     ///         calling `registry.registerTenderAddress(...)`
     function isTenderAddress(address tenderAddress)

--- a/package-lock.json
+++ b/package-lock.json
@@ -18163,7 +18163,7 @@
       "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
     },
     "scrypt-shim": {
-      "version": "github:web3-js/scrypt-shim#be5e616323a8b5e568788bf94d03c1b8410eac54",
+      "version": "github:web3-js/scrypt-shim#aafdadda13e660e25e1c525d1f5b2443f5eb1ebb",
       "from": "github:web3-js/scrypt-shim",
       "requires": {
         "scryptsy": "^2.1.0",
@@ -20794,7 +20794,7 @@
       }
     },
     "websocket": {
-      "version": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
+      "version": "github:web3-js/WebSocket-Node#ef5ea2f41daf4a2113b80c9223df884b4d56c400",
       "from": "github:web3-js/WebSocket-Node#polyfill/globalThis",
       "requires": {
         "debug": "^2.2.0",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -6,6 +6,8 @@ import * as sign from './commands/sign'
 import * as submit from './commands/submit'
 import * as upgrade from './commands/upgrade'
 
+import * as tenderBatch from './commands/tenderBatch'
+
 import * as deploySwap from './commands/swap/deploySwap'
 import * as swapLock from './commands/swap/lock'
 import * as swapGenerate from './commands/swap/generate'
@@ -16,5 +18,5 @@ import * as swapClaimRefund from './commands/swap/claimRefund'
 export {
     deploy, info, merge, prepareTx, sign, submit, upgrade,
     deploySwap, swapGenerate, swapLock, swapSwapConfirm,
-    swapRedeem, swapClaimRefund
+    swapRedeem, swapClaimRefund, tenderBatch
 }

--- a/src/commands/tenderBatch.ts
+++ b/src/commands/tenderBatch.ts
@@ -1,0 +1,106 @@
+import * as fs from 'fs'
+import { promisify } from 'util'
+import * as Utils from 'web3-utils'
+import { promptAndLoadEnv, promptIfNeeded } from '../prompt'
+import withErrors from '../utils/withErrors'
+import { Address, NetworkName, ContractName, BN, validateType } from '../types'
+
+const readFile = promisify(fs.readFile)
+
+
+interface TenderBatchArguments {
+    network: NetworkName
+    from: Address
+    registry: Address
+    file: string
+    gasPrice: BN
+}
+
+async function readAddressesFrom(file: string) {
+    const batch =
+        (await readFile(file))
+            .toString()
+            .split('\n')
+            .map(s => s.trim())
+            .filter(s => s !== '')
+    for (let addr of batch) {
+        if (validateType(addr, 'address') !== true) {
+            throw new Error(`${addr} is not a valid Ethereum address`)
+        }
+    }
+    console.log(`Batch: ${batch}`)
+    return batch
+}
+
+async function registerTenderAddressBatch(
+    options: Partial<TenderBatchArguments>
+) {
+    const env = await promptAndLoadEnv({networkInOpts: options.network})
+    const existingAccounts = await env.web3.eth.getAccounts()
+    let registryAddr = null
+    try {
+        env.getContractAddress('Registry')
+    } catch (_) { }
+    const args = await promptIfNeeded(options, [
+        {
+            type: 'list',
+            name: 'from',
+            message: 'Send the tx from (should be "registry backend" address)',
+            choices: existingAccounts,
+            validate:
+                async (address: Address) => existingAccounts.includes(address),
+        },
+        {
+            type: 'input',
+            name: 'registry',
+            message: 'Address of the registry contract',
+            default: registryAddr,
+            validate:
+                async (addr: string) => validateType(addr, 'address'),
+        },
+        {
+            type: 'file-tree-selection',
+            name: 'file',
+            message: 'File with tender addresses to register',
+        },
+        {
+            type: 'number',
+            name: 'gasPrice',
+            message: 'Gas price (in GWei)',
+            default: Utils.fromWei(env.txParams.gasPrice.toString(), 'gwei')
+        },
+    ]) as TenderBatchArguments
+
+    const registry = env.getContract('Registry', args.registry)
+    const batch = await readAddressesFrom(args.file)
+    await registry.methods
+            .registerTenderAddressBatch(batch)
+            .send({
+                from: args.from,
+                gasPrice: Utils.toWei(args.gasPrice, 'gwei')
+            })
+}
+
+function register(program: any) {
+    program
+        .command('tender-batch')
+        .description(
+            'Register several tender addresses in batch.'
+        )
+        .option('-n, --network <network_name>', 'network to use')
+        .option(
+            '--from <address>',
+            'address from which you send the transaction'
+        )
+        .option(
+            '--registry <address>',
+            'the address of the registry contract'
+        )
+        .option(
+            '--file <output_file>',
+            'the file to read the tender addresses from'
+        )
+        .action(withErrors(registerTenderAddressBatch))
+}
+
+module.exports = { register }


### PR DESCRIPTION
Problem: We need to register several tender addresses in batch, buth neither Registry contract nor the CLI supports such a workflow

Solution: Add `registerTenderAddressBatch` entrypoint and `tender-batch` CLI command.